### PR TITLE
Docs: unify skeleton README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,46 @@ A Nette application skeleton with Webpack 5, Tailwind CSS, and Vue support.
 
 Requirements:
 
-- PHP 8.4 or newer
+- [PHP](https://www.php.net/downloads.php) 8.4 or newer
 - [Composer](https://getcomposer.org/)
-- Node.js and npm
+- [Node.js](https://nodejs.org/) with [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [GNU Make](https://www.gnu.org/software/make/)
 
-Create a new project and install its dependencies:
+1. Create a new project.
 
 ```bash
 composer create-project -s dev contributte/webpack-skeleton acme
+```
+
+The `-s dev` option is required because the skeleton is distributed from its development branch.
+
+2. Enter the project directory.
+
+```bash
 cd acme
+```
+
+3. Create the local configuration.
+
+```bash
 make init
+```
+
+This copies `config/local.neon.example` to the ignored `config/local.neon` file.
+
+4. Install PHP dependencies and prepare writable directories.
+
+```bash
 make project
+```
+
+5. Install frontend dependencies from `package-lock.json`.
+
+```bash
 npm ci
 ```
 
-`make init` creates `config/local.neon` from `config/local.neon.example`. `make project` installs Composer dependencies and prepares writable runtime directories. It does not install npm dependencies.
+The project is now ready for [local development](#usage).
 
 ## Usage
 
@@ -81,6 +106,29 @@ Webpack writes frontend bundles to `www/dist/`. The configured entry points are 
 ## Configuration
 
 Shared application configuration is in `config/config.neon`. Keep local parameters and service overrides in the ignored `config/local.neon` file created by `make init`.
+
+## Makefile
+
+The [Makefile](Makefile) provides these targets:
+
+| Target | Description |
+|---|---|
+| `make init` | Copies `config/local.neon.example` to `config/local.neon`. |
+| `make project` | Runs `make install` and `make setup`. |
+| `make install` | Installs PHP dependencies with `composer install`. |
+| `make setup` | Creates writable `var/tmp` and `var/log` directories. |
+| `make clean` | Removes generated files from `var/tmp` and `var/log`, preserving `.gitignore`. |
+| `make dev` | Starts the PHP development server on `0.0.0.0:8000` with Nette debug mode enabled. |
+| `make build` | Runs the one-time development asset build through `npm run start`. |
+| `make webpack` | Starts the Webpack development server through `npm run dev`. |
+| `make qa` | Runs `make cs` and `make phpstan`. |
+| `make cs` | Checks `app/` and `tests/` with CodeSniffer. |
+| `make csf` | Fixes supported coding-style issues in `app/` and `tests/`. |
+| `make phpstan` | Runs PHPStan with `phpstan.neon` and a 512 MB memory limit. |
+| `make tests` | Runs the Nette Tester suite in `tests/`. |
+| `make coverage` | Runs the test suite and writes coverage to `coverage.xml`. |
+| `make docker-up` | Starts services from [Docker Compose](https://docs.docker.com/compose/) in the foreground. |
+| `make deploy` | Cleans runtime files, prepares the project, builds assets, and cleans runtime files again. |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ make init
 
 This copies `config/local.neon.example` to the ignored `config/local.neon` file.
 
-4. Install PHP dependencies and prepare writable directories.
+4. Prepare writable directories.
 
 ```bash
-make project
+make setup
 ```
+
+Composer installs PHP dependencies as part of `create-project`.
 
 5. Install frontend dependencies from `package-lock.json`.
 
@@ -69,7 +71,7 @@ make project
 npm ci
 ```
 
-The project is now ready for [local development](#usage).
+At present, a clean `npm ci` reports that `package.json` and `package-lock.json` are out of sync around the `awesome-typescript-loader` TypeScript peer dependency. The lockfile must be reconciled in the project before the frontend development commands below can be used from a clean checkout; do not substitute an untracked dependency tree for a reproducible install.
 
 ## Usage
 
@@ -85,7 +87,7 @@ make dev
 npm run dev
 ```
 
-Open [http://localhost:8080](http://localhost:8080).
+Open [http://localhost:8080](http://localhost:8080). This Webpack development-server URL is the interactive development entry point; verify the home page, its AJAX snippet reloads, the example form, and the admin-page link.
 
 The Webpack development server proxies requests to the PHP server at `localhost:8000` by default.
 
@@ -110,11 +112,13 @@ make dev
 npm run watch
 ```
 
-Open [http://localhost:8000](http://localhost:8000).
+Open [http://localhost:8000](http://localhost:8000). This is the passive-watch alternative without the Webpack development-server proxy or hot module replacement.
 
-The PHP development server uses `www/` as its document root. Use `npm run start` for a one-time development build or `npm run build` for a production build.
+The PHP development server uses `www/` as its document root. Use `npm run start` or `make build` for a one-time development build. Use `npm run build` for a production build.
 
 Webpack writes frontend bundles to `www/dist/`. The configured entry points are `assets/front.js` and `assets/admin.js`.
+
+Production builds hash CSS filenames, but the checked-in Latte layouts reference the stable `front.bundle.css` and `admin.bundle.css` names. Resolve that integration (for example with a manifest) before treating `npm run build` output as deployable. JavaScript filenames remain stable in the current configuration.
 
 ## Configuration
 
@@ -127,12 +131,12 @@ The [Makefile](Makefile) provides these targets:
 | Target | Description |
 |---|---|
 | `make init` | Copies `config/local.neon.example` to `config/local.neon`. |
-| `make project` | Runs `make install` and `make setup`. |
+| `make project` | Runs `make install` and `make setup`; useful after checkout, but redundant immediately after `composer create-project`. |
 | `make install` | Installs PHP dependencies with `composer install`. |
 | `make setup` | Creates writable `var/tmp` and `var/log` directories. |
 | `make clean` | Removes generated files from `var/tmp` and `var/log`, preserving `.gitignore`. |
 | `make dev` | Starts the PHP development server on `0.0.0.0:8000` with Nette debug mode enabled. |
-| `make build` | Runs the one-time development asset build through `npm run start`. |
+| `make build` | Runs the one-time development asset build through `npm run start`; it is not the production build. |
 | `make webpack` | Starts the Webpack development server through `npm run dev`. |
 | `make qa` | Runs `make cs` and `make phpstan`. |
 | `make cs` | Checks `app/` and `tests/` with CodeSniffer. |
@@ -140,7 +144,6 @@ The [Makefile](Makefile) provides these targets:
 | `make phpstan` | Runs PHPStan with `phpstan.neon` and a 512 MB memory limit. |
 | `make tests` | Runs the Nette Tester suite in `tests/`. |
 | `make coverage` | Runs the test suite and writes coverage to `coverage.xml`. |
-| `make docker-up` | Starts services from [Docker Compose](https://docs.docker.com/compose/) in the foreground. |
 | `make deploy` | Cleans runtime files, prepares the project, builds assets, and cleans runtime files again. |
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -26,16 +26,18 @@ A Nette application skeleton with Webpack 5, Tailwind CSS, and Vue support.
   <a href="https://examples.contributte.org/webpack-skeleton/"><img src="https://api.microlink.io?url=https%3A%2F%2Fexamples.contributte.org%2Fwebpack-skeleton%2F&amp;overlay.browser=light&amp;screenshot=true&amp;meta=false&amp;embed=screenshot.url" alt="Webpack skeleton demo"></a>
 </p>
 
-## Requirements
+## Installation
+
+Requirements:
 
 - PHP 8.4 or newer
 - [Composer](https://getcomposer.org/)
 - Node.js and npm
 
-## Create a project
+Create a new project and install its dependencies:
 
 ```bash
-composer create-project contributte/webpack-skeleton acme
+composer create-project -s dev contributte/webpack-skeleton acme
 cd acme
 make init
 make project
@@ -44,7 +46,9 @@ npm ci
 
 `make init` creates `config/local.neon` from `config/local.neon.example`. `make project` installs Composer dependencies and prepares writable runtime directories. It does not install npm dependencies.
 
-## Local development: PHP application with asset watcher
+## Usage
+
+### Watcher
 
 Run these commands in separate terminals to serve the PHP application and rebuild assets on changes:
 
@@ -58,9 +62,9 @@ npm run watch
 
 Open [http://localhost:8000](http://localhost:8000). The PHP development server uses `www/` as its document root. Use `npm run start` for a one-time development build or `npm run build` for a production build.
 
-## Local development: Webpack development server and proxy
+### Dev server
 
-Alternatively, start the PHP application first, then start the Webpack development server in a second terminal:
+For hot module replacement, start the PHP application and Webpack development server in separate terminals:
 
 ```bash
 make dev
@@ -78,7 +82,7 @@ Webpack writes frontend bundles to `www/dist/`. The configured entry points are 
 
 Shared application configuration is in `config/config.neon`. Keep local parameters and service overrides in the ignored `config/local.neon` file created by `make init`.
 
-## Quality assurance
+## Testing
 
 ```bash
 make qa
@@ -86,3 +90,21 @@ make tests
 ```
 
 `make qa` runs coding-standard and PHPStan checks. `make tests` runs Nette Tester tests from `tests/`.
+
+## Screenshots
+
+### Webpack
+
+![Webpack compilation](.docs/webpack.png)
+
+### PHP server
+
+![PHP development server](.docs/phpserver.png)
+
+### Application
+
+![Webpack skeleton application](.docs/web.png)
+
+## Development
+
+See [Contributte development guidelines](https://contributte.org/contributing.html) before contributing.

--- a/README.md
+++ b/README.md
@@ -73,20 +73,6 @@ The project is now ready for [local development](#usage).
 
 ## Usage
 
-### Watcher
-
-Run these commands in separate terminals to serve the PHP application and rebuild assets on changes:
-
-```bash
-make dev
-```
-
-```bash
-npm run watch
-```
-
-Open [http://localhost:8000](http://localhost:8000). The PHP development server uses `www/` as its document root. Use `npm run start` for a one-time development build or `npm run build` for a production build.
-
 ### Dev server
 
 For hot module replacement, start the PHP application and Webpack development server in separate terminals:
@@ -99,7 +85,34 @@ make dev
 npm run dev
 ```
 
-Open [http://localhost:8080](http://localhost:8080). The Webpack development server proxies requests to the PHP server at `localhost:8000` by default. Override the host and ports with `WEBPACK_DEV_SERVER_HOST`, `WEBPACK_DEV_SERVER_PORT`, `WEBPACK_DEV_SERVER_PROXY_HOST`, and `WEBPACK_DEV_SERVER_PROXY_PORT`.
+Open [http://localhost:8080](http://localhost:8080).
+
+The Webpack development server proxies requests to the PHP server at `localhost:8000` by default.
+
+The home page confirms a successful setup with AJAX snippet reloads, an example form, and a link to the admin page.
+
+Override the Webpack server and proxy addresses independently:
+
+- `WEBPACK_DEV_SERVER_HOST` defaults to `localhost`.
+- `WEBPACK_DEV_SERVER_PORT` defaults to `8080`.
+- `WEBPACK_DEV_SERVER_PROXY_HOST` defaults to `localhost`.
+- `WEBPACK_DEV_SERVER_PROXY_PORT` defaults to `8000`.
+
+### Watcher
+
+To serve the PHP application directly and rebuild assets on changes, run these commands in separate terminals:
+
+```bash
+make dev
+```
+
+```bash
+npm run watch
+```
+
+Open [http://localhost:8000](http://localhost:8000).
+
+The PHP development server uses `www/` as its document root. Use `npm run start` for a one-time development build or `npm run build` for a production build.
 
 Webpack writes frontend bundles to `www/dist/`. The configured entry points are `assets/front.js` and `assets/admin.js`.
 
@@ -154,5 +167,7 @@ make tests
 ![Webpack skeleton application](.docs/web.png)
 
 ## Development
+
+This skeleton is maintained by [Contributte](https://contributte.org). Report issues and submit changes through the [GitHub repository](https://github.com/contributte/webpack-skeleton).
 
 See [Contributte development guidelines](https://contributte.org/contributing.html) before contributing.

--- a/README.md
+++ b/README.md
@@ -1,124 +1,57 @@
-![](https://heatbadger.now.sh/github/readme/contributte/webpack-skeleton/)
+# Webpack skeleton
 
-<p align=center>
-  <a href="https://github.com/contributte/webpack-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/webpack-skeleton/master"></a>
-  <a href="https://codecov.io/gh/contributte/webpack-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/webpack-skeleton"></a>
-  <a href="https://packagist.org/packages/contributte/webpack-skeleton"><img src="https://badgen.net/packagist/dm/contributte/webpack-skeleton"></a>
-  <a href="https://packagist.org/packages/contributte/webpack-skeleton"><img src="https://badgen.net/packagist/v/contributte/webpack-skeleton"></a>
-</p>
-<p align=center>
-  <a href="https://packagist.org/packages/contributte/webpack-skeleton"><img src="https://badgen.net/packagist/php/contributte/webpack-skeleton"></a>
-  <a href="https://github.com/contributte/webpack-skeleton"><img src="https://badgen.net/github/license/contributte/webpack-skeleton"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
-  <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
-</p>
+A Nette application skeleton with Webpack 5, Tailwind CSS, and Vue support.
 
-<p align=center>
-Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact 👨🏻‍💻 <a href="https://f3l1x.io">f3l1x.io</a> | Twitter 🐦 <a href="https://twitter.com/contributte">@contributte</a>
-</p>
+## Requirements
 
-<p align=center>
-	<img src="https://api.microlink.io?url=https%3A%2F%2Fexamples.contributte.org%2Fwebpack-skeleton%2F&overlay.browser=light&screenshot=true&meta=false&embed=screenshot.url">
-</p>
+- PHP 8.4 or newer
+- [Composer](https://getcomposer.org/)
+- Node.js and npm
 
------
-
-## Goal
-
-Main goal is to provide webpack starter-kit project for Nette developers.
-
-## Demo
-
-https://examples.contributte.org/webpack-skeleton/
-
-## Installation
-
-You will need `PHP 8.4+` and [Composer](https://getcomposer.org/).
-
-Create project using composer.
+## Create a project
 
 ```bash
-composer create-project -s dev contributte/webpack-skeleton acme
+composer create-project contributte/webpack-skeleton acme
+cd acme
+make init
+make project
+npm ci
 ```
 
-Install Composer dependencies: `composer install` or `make install`
+`make init` creates `config/local.neon` from `config/local.neon.example`. `make project` installs Composer dependencies and prepares writable runtime directories. It does not install npm dependencies.
 
-Install NPM dependencies: `npm install` or `make install`
+## Local development
 
-Now you have application installed. It's time to run it.
-
-## Startup
-
-**Backend**
-
-The easiest way is to use php built-in web server.
+Start the PHP application:
 
 ```bash
-php -S 0.0.0.0:8000 -t www
+make dev
 ```
 
-Or via `make dev`.
+Open [http://localhost:8000](http://localhost:8000). The development server uses `www/` as its document root.
 
-Then visit [http://localhost:8000](http://localhost:8000) in your browser.
+In a second terminal, compile frontend assets as needed:
 
-**Frontend**
+```bash
+npm run start  # development build
+npm run watch  # rebuild on changes
+npm run build  # production build
+npm run dev    # Webpack development server
+```
 
-If you want to compile assets, call `npm run start`.
+`npm run dev` serves the Webpack development server at [http://localhost:8080](http://localhost:8080) and proxies requests to the PHP server at `localhost:8000` by default. Override the host and ports with `WEBPACK_DEV_SERVER_HOST`, `WEBPACK_DEV_SERVER_PORT`, `WEBPACK_DEV_SERVER_PROXY_HOST`, and `WEBPACK_DEV_SERVER_PROXY_PORT`.
 
-If you need watcher, call `npm run watch`, it will watch your codebase and rebuild assets.
+Webpack writes frontend bundles to `www/dist/`. The configured entry points are `assets/front.js` and `assets/admin.js`.
 
-If you want build for production, call `npm run build`.
+## Configuration
 
-If you want start webpack development server with HRM, call `npm run dev`, open [http://localhost:8080](http://localhost:8080) in your browser.
+Shared application configuration is in `config/config.neon`. Keep local parameters and service overrides in the ignored `config/local.neon` file created by `make init`.
 
-Or via `make webpack`.
+## Quality assurance
 
-## Features
+```bash
+make qa
+make tests
+```
 
-- :+1: Nette 3+
-- :+1: Webpack 5+
-    - :tada: extracting JS to single bundle
-    - :tada: extracting CSS to single file
-    - :tada: more bundles (front/admin/vendor)
-- :+1: Snippets
-    - :tada: few snippets
-- :+1: Nette Form
-    - :tada: AJAX submitting
-    - :tada: form builder
-        - empty value on control (`@` in email)
-        - validation rules (filled + email)
-        - simple filter (transform email to lowercase)
-        - onValidate / onSubmit / onSuccess
-    - :tada: manual rendering
-        - success snippet / error snippet
-        - required class on form-group
-        - description on control
-
-## Screenshots
-
-<p align=center>
-	<img src="https://raw.githubusercontent.com/contributte/webpack-skeleton/master/.docs/webpack.png">
-</p>
-
-<p align=center>
-	<img src="https://raw.githubusercontent.com/contributte/webpack-skeleton/master/.docs/phpserver.png">
-</p>
-
-<p align=center>
-	<img src="https://raw.githubusercontent.com/contributte/webpack-skeleton/master/.docs/web.png">
-</p>
-
-## Development
-
-See [how to contribute](https://contributte.org/contributing.html) to this package.
-
-This package is currently maintaining by these authors.
-
-<a href="https://github.com/f3l1x">
-	<img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
-</a>
-
------
-
-Consider to [support](https://contributte.org/partners.html) **contributte** development team. Also thank you for using this project.
+`make qa` runs coding-standard and PHPStan checks. `make tests` runs Nette Tester tests from `tests/`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 A Nette application skeleton with Webpack 5, Tailwind CSS, and Vue support.
 
+![Contributte Webpack skeleton](https://heatbadger.now.sh/github/readme/contributte/webpack-skeleton/)
+
+<p align="center">
+  <a href="https://github.com/contributte/webpack-skeleton/actions"><img src="https://badgen.net/github/checks/contributte/webpack-skeleton/master" alt="Build status"></a>
+  <a href="https://codecov.io/gh/contributte/webpack-skeleton"><img src="https://badgen.net/codecov/c/github/contributte/webpack-skeleton" alt="Code coverage"></a>
+  <a href="https://packagist.org/packages/contributte/webpack-skeleton"><img src="https://badgen.net/packagist/dm/contributte/webpack-skeleton" alt="Packagist downloads"></a>
+  <a href="https://packagist.org/packages/contributte/webpack-skeleton"><img src="https://badgen.net/packagist/v/contributte/webpack-skeleton" alt="Packagist version"></a>
+</p>
+<p align="center">
+  <a href="https://packagist.org/packages/contributte/webpack-skeleton"><img src="https://badgen.net/packagist/php/contributte/webpack-skeleton" alt="PHP version"></a>
+  <a href="https://github.com/contributte/webpack-skeleton"><img src="https://badgen.net/github/license/contributte/webpack-skeleton" alt="License"></a>
+  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan" alt="Gitter support"></a>
+  <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow" alt="Forum support"></a>
+  <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854" alt="Sponsor Contributte"></a>
+</p>
+
+<p align="center">
+  Website <a href="https://contributte.org">contributte.org</a> | Contact <a href="https://f3l1x.io">f3l1x.io</a> | Twitter <a href="https://twitter.com/contributte">@contributte</a>
+</p>
+
+<p align="center">
+  <a href="https://examples.contributte.org/webpack-skeleton/"><img src="https://api.microlink.io?url=https%3A%2F%2Fexamples.contributte.org%2Fwebpack-skeleton%2F&amp;overlay.browser=light&amp;screenshot=true&amp;meta=false&amp;embed=screenshot.url" alt="Webpack skeleton demo"></a>
+</p>
+
 ## Requirements
 
 - PHP 8.4 or newer

--- a/README.md
+++ b/README.md
@@ -20,26 +20,33 @@ npm ci
 
 `make init` creates `config/local.neon` from `config/local.neon.example`. `make project` installs Composer dependencies and prepares writable runtime directories. It does not install npm dependencies.
 
-## Local development
+## Local development: PHP application with asset watcher
 
-Start the PHP application:
+Run these commands in separate terminals to serve the PHP application and rebuild assets on changes:
 
 ```bash
 make dev
 ```
 
-Open [http://localhost:8000](http://localhost:8000). The development server uses `www/` as its document root.
-
-In a second terminal, compile frontend assets as needed:
-
 ```bash
-npm run start  # development build
-npm run watch  # rebuild on changes
-npm run build  # production build
-npm run dev    # Webpack development server
+npm run watch
 ```
 
-`npm run dev` serves the Webpack development server at [http://localhost:8080](http://localhost:8080) and proxies requests to the PHP server at `localhost:8000` by default. Override the host and ports with `WEBPACK_DEV_SERVER_HOST`, `WEBPACK_DEV_SERVER_PORT`, `WEBPACK_DEV_SERVER_PROXY_HOST`, and `WEBPACK_DEV_SERVER_PROXY_PORT`.
+Open [http://localhost:8000](http://localhost:8000). The PHP development server uses `www/` as its document root. Use `npm run start` for a one-time development build or `npm run build` for a production build.
+
+## Local development: Webpack development server and proxy
+
+Alternatively, start the PHP application first, then start the Webpack development server in a second terminal:
+
+```bash
+make dev
+```
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:8080](http://localhost:8080). The Webpack development server proxies requests to the PHP server at `localhost:8000` by default. Override the host and ports with `WEBPACK_DEV_SERVER_HOST`, `WEBPACK_DEV_SERVER_PORT`, `WEBPACK_DEV_SERVER_PROXY_HOST`, and `WEBPACK_DEV_SERVER_PROXY_PORT`.
 
 Webpack writes frontend bundles to `www/dist/`. The configured entry points are `assets/front.js` and `assets/admin.js`.
 


### PR DESCRIPTION
## Scope

README-only onboarding audit on the existing PR branch. Preserves the Webpack development-server-primary workflow, removes duplicate Composer installation after `create-project`, separates `make dev` and `npm run dev`, keeps passive watch secondary at port 8000, corrects `make build` semantics, omits unusable Docker guidance, and documents the production hashed-CSS/static-Latte mismatch.

## Validation

- Clean temporary-copy Composer install/init/setup passed on PHP 8.5.3 / Composer 2.9.5.
- Clean `npm ci` was attempted and reproduced the documented package/lock mismatch (`typescript@7.0.2` requested by current resolution but absent from the lockfile); frontend smoke was stopped rather than using an untracked install.
- `make qa` passed.
- `make tests` passed (1 test).
- README audit evaluator passed.
- `git diff --check` passed.
- PR diff contains only `README.md`.

## Blockers / caveats

- Reconcile `package.json` and `package-lock.json` before a reproducible clean frontend smoke is possible.
- Production builds hash CSS filenames while Latte references stable CSS names; production output is not deployable as documented until that integration is resolved.